### PR TITLE
Change “Toggle comment” to be more strict when checking the TM_COMMENT_DISABLE_INDENT variable

### DIFF
--- a/Commands/Toggle comment.plist
+++ b/Commands/Toggle comment.plist
@@ -59,7 +59,7 @@ var_suffixes.each do |suffix|
           :end       =&gt; ENV["TM_COMMENT_END#{suffix}"]   || "",
           :mode      =&gt; ENV["TM_COMMENT_MODE#{suffix}"]  ||
                         (ENV["TM_COMMENT_END#{suffix}"] ? "block" : "line"),
-          :no_indent =&gt; ENV["TM_COMMENT_DISABLE_INDENT#{suffix}"] }
+          :no_indent =&gt; (ENV["TM_COMMENT_DISABLE_INDENT#{suffix}"] || "").downcase == "yes" }
   
   com[:esc_start], com[:esc_end] = [com[:start], com[:end]].map do |str|
     str.gsub(/[\\|()\[\].?*+{}^$]/, '\\\\\&amp;').


### PR DESCRIPTION
If a bundle by default set `TM_COMMENT_DISABLE_INDENT` to `'yes'`, then it could not be disabled through use of a .tm_properties file or by the “Variables” section in the Preferences pane.

For example the CSS bundle sets TM_COMMENT_DISABLE_INDENT to `yes`. With this change I can now place the following in a .tm_properties file:

```
[ source.css ]
TM_COMMENT_DISABLE_INDENT = no
```
