### PR TITLE
Fixing the selection comment

### DIFF
--- a/Commands/Toggle comment.plist
+++ b/Commands/Toggle comment.plist
@@ -144,7 +144,7 @@ when "block" # apply comment around selection
   elsif default[:no_indent]
     out default[:start], text, default[:end]
   else
-    lines = text.to_a
+    lines = Array(text)
     if lines.empty?
       out default[:start], default[:end]
     else


### PR DESCRIPTION
This commit fixes a bug when trying to comment a single-line selection

## How to reproduce:

I faced this bug several times but when I decided to fix it I was editing an HTML file with the following content

    <span class="filtersBar-toggle mod-adminUser">
      <i class="fa fa-group"></i>
      <i class="fa fa-caret-down filtersBar-toggleCaret"></i>
    </span>

I selected `<i class="fa fa-group"></i>` and used the `cmd-/` shortcut.

## Expected result

I expected the code to be changed to `<!-- <i class="fa fa-group"></i> -->`.

## Actual result

I got an error stating that the string `"<i class="fa fa-group"></i>"` did not respond to `to_a`.

## The fix

By changing `text.to_a` to `Array(text)` it ensures that if `text` is a _String_ or already an _Array_ it will return an Array containing `text`. (see https://ruby-doc.org/core-2.2.0/Kernel.html#method-i-Array for more information).